### PR TITLE
ASRAgent에서 stopRecognition()과 startRecognition()을 연속적으로 호출하면 순서보장이 안되던 문제 수정

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -70,9 +70,18 @@ public final class ASRAgent: ASRAgentProtocol {
             // `ASRRequest` -> `FocusState` -> EndPointDetector` -> `ASRAgentDelegate`
             // release asrRequest
             if asrState == .idle {
-                pendingStateDialogRequestId = nil
-                asrRequest = nil
-                releaseFocusIfNeeded()
+                switch asrResult {
+                case let .cancel(_, dialogRequestId):
+                    guard let cancelDialogRequestId = dialogRequestId else { fallthrough }
+                    guard asrRequest?.eventIdentifier.dialogRequestId == cancelDialogRequestId else { 
+                        log.info("asrRequest's dialogRequestId is not correspond cancel dialogRequestId")
+                        break
+                    }
+                default:
+                    pendingStateDialogRequestId = nil
+                    asrRequest = nil
+                    releaseFocusIfNeeded()
+                }
             }
             
             // Stop EPD
@@ -316,7 +325,7 @@ public extension ASRAgent {
             
             self.expectSpeech = nil
             if self.asrState != .idle {
-                self.asrResult = .cancel()
+                self.asrResult = .cancel(dialogRequestId: asrRequest?.eventIdentifier.dialogRequestId)
             }
         }
     }

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRResult.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRResult.swift
@@ -36,7 +36,7 @@ public enum ASRResult {
     /// - Parameter header: The header of the originally handled directive.
     case complete(text: String, header: Downstream.Header, requestType: String? = nil)
     /// 음성 인식 요청 취소
-    case cancel(header: Downstream.Header? = nil)
+    case cancel(header: Downstream.Header? = nil, dialogRequestId: String? = nil)
     /// The `ASR.ExpectSpeech` directive has been cancelled.
     case cancelExpectSpeech
     /// 음성 인식 결과 실패


### PR DESCRIPTION
### Description
- ASRAgent에서 stopRecognition()과 startRecognition()을 연속적으로 호출하면 순서보장이 안되던 문제 수정