### PR TITLE
Player에서 Stop 될때, 캐싱된 파일 제거하도록 적용

### DIFF
--- a/NuguCore/Sources/MediaPlayer/MediaPlayer.swift
+++ b/NuguCore/Sources/MediaPlayer/MediaPlayer.swift
@@ -78,6 +78,10 @@ extension MediaPlayer {
             return
         }
         
+        if let cacheKey = playerItem?.cacheKey {
+            MediaCacheManager.setModifiedDateForCacheFile(key: cacheKey)
+        }
+        
         mediaPlayer.replaceCurrentItem(with: nil)
         removePlayerItemObserver()  // CHECK-ME: 타이밍 이슈 없을지 확인
         
@@ -448,11 +452,6 @@ private extension MediaPlayer {
             log.debug("playback status changed to: \(notification)")
             
             switch notification {
-            case .readyToPlay:
-                if let cacheKey = object.cacheKey {
-                    MediaCacheManager.setModifiedDateForCacheFile(key: cacheKey)
-                }
-                
             case .failed:
                 log.debug("playback failed reason: \(object.error.debugDescription)")
                 self.delegate?.mediaPlayerStateDidChange(.error(error: object.error ?? MediaPlayableError.unknown), mediaPlayer: self)


### PR DESCRIPTION
### Description
- Player에서 Stop 될때, 캐싱된 파일 제거하도록 적용
    - ReadyToPlay단계에서 해당 파일을 제거해버려서 버퍼에도 담기기 전에 플레이어가 재생상태가 되어버리는 이슈 발생
    - 버퍼에 담기는 동안에 영향이 없도록 정지될때 캐싱된 파일 제거 