### PR TITLE
포커스 요청하는 시점을 TTS.Speak Directive -> TTS.Speak Attachment 로 이동

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/TextToSpeech/TTSAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/TextToSpeech/TTSAgent.swift
@@ -408,7 +408,7 @@ private extension TTSAgent {
                 
                 log.debug(directive.header.messageId)
                 self.currentPlayer = player
-                self.focusManager.requestFocus(channelDelegate: self)
+                
                 self.ttsNotificationQueue.async { [weak self] in
                     self?.post(NuguAgentNotification.TTS.Result(text: player.payload.text, header: player.header))
                 }
@@ -478,6 +478,8 @@ private extension TTSAgent {
                     log.warning("MediaOpusStreamDataSource not exist or dialogRequesetId not valid")
                     return
                 }
+                
+                focusManager.requestFocus(channelDelegate: self)
             }
             
             #if DEBUG


### PR DESCRIPTION
### Description
- 포커스 요청하는 시점을 TTS.Speak Directive -> TTS.Speak Attachment 로 이동

### Focus
- 기존에는 TTS.Speak directive를 수신 -> 포커스를 요청 -> ttsState=playing 이 되고 있음
- 문제는 TTS.Speak directive를 수신하고 다른 directive가 처리된 이후에 TTS.Speak attachment가 내려오는데 attachment를 받기전까지 음성은 나오지않지만 playing상태에 머물러버림
- TTSPlayer는 attachment를 받지 않아도 playing이 되버려서 발생하는 문제(안드로이드는 그렇지 않다고 함)
- player자체를 수정해버리면 사이드이펙트가 크게 날 우려가 있어서 focus를 가져오는 시점을 attachment를 받는 시점으로 변경