### PR TITLE
mediaPlayer가 재생을 했을 때 재생할 수 없는 상태면 pause 로 변경

### DIFF
--- a/NuguCore/Sources/MediaPlayer/MediaPlayer.swift
+++ b/NuguCore/Sources/MediaPlayer/MediaPlayer.swift
@@ -76,6 +76,11 @@ extension MediaPlayer {
         }
         
         delegate?.mediaPlayerStateDidChange(.start, mediaPlayer: self)
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self, mediaPlayer.timeControlStatus != .playing else { return }
+            delegate?.mediaPlayerStateDidChange(.pause, mediaPlayer: self)
+        }
     }
     
     public func stop() {


### PR DESCRIPTION
### Description
- mediaPlayer가 재생을 했을 때 재생할 수 없는 상태면 pause 로 변경

### Focus
- 음악이 종료되는 시점에 외부에서 오디오 세션을 가져가면 타이밍이 꼬여서 finish event를 전송하고, play directive를 수신함.
- pause를 해도, 이전 player가 정지되는거고 새로 생성된 player는 재생을 시킴.
- 오디오세션이 없어서 실제 음악은 재생하지 못하는데 state는 start가 되어버림.
- start를 요청하고, 0.1초 뒤에 player의 상태가 playing이 아니면 state를 pause로 바꾸도록 변경