### PR TITLE
NuguClientBuilder에서 requestTimeout을 설정할 수 있도록 변경

### DIFF
--- a/NuguClientKit/Sources/Client/NuguClient+Builder.swift
+++ b/NuguClientKit/Sources/Client/NuguClient+Builder.swift
@@ -305,6 +305,13 @@ public extension NuguClient {
             return self
         }
         
+        @discardableResult public func setRequestTimeout(_ timeInterval: TimeInterval) -> Self {
+            if let streamDataRouter = streamDataRouter as? StreamDataRouter {
+                streamDataRouter.setRequestTimeout(timeInterval)
+            }
+            return self
+        }
+        
         /**
          Instantiate the NuguClient.
          

--- a/NuguCore/Sources/Network/Api/NuguApiProvider.swift
+++ b/NuguCore/Sources/Network/Api/NuguApiProvider.swift
@@ -203,6 +203,10 @@ class NuguApiProvider: NSObject {
         
         return partObserver.compactMap { $0 }
     }
+    
+    func setRequestTimeout(_ timeInterval: TimeInterval) {
+        requestTimeout = timeInterval
+    }
 }
 
 // MARK: - APIs

--- a/NuguCore/Sources/Network/Api/NuguApiProvider.swift
+++ b/NuguCore/Sources/Network/Api/NuguApiProvider.swift
@@ -25,7 +25,7 @@ import NuguUtils
 import RxSwift
 
 class NuguApiProvider: NSObject {
-    private let requestTimeout: TimeInterval
+    private var requestTimeout: TimeInterval
     private var candidateResourceServers: [String]?
     private var disposeBag = DisposeBag()
     private let processorQueue = DispatchQueue(label: "com.skt.Romaine.nugu_api_provider.processor")

--- a/NuguCore/Sources/StreamData/StreamDataRouter.swift
+++ b/NuguCore/Sources/StreamData/StreamDataRouter.swift
@@ -41,6 +41,10 @@ public class StreamDataRouter: StreamDataRoutable {
         serverInitiatedDirectiveReceiver = ServerSentEventReceiver(apiProvider: nuguApiProvider)
         self.directiveSequencer = directiveSequencer
     }
+    
+    public func setRequestTimeout(_ timeoutInterval: TimeInterval) {
+        nuguApiProvider.setRequestTimeout(timeoutInterval)
+    }
 }
 
 // MARK: - APIs for Server side event


### PR DESCRIPTION
### Description
- NuguClientBuilder에서 requestTimeout을 설정할 수 있도록 변경

### Focus
- timeout 값을 런타임에서 연속적으로 바꾸는 로직은 위험하다고 판단되서 builder에서만 설정할 수 있도록 처리
- builder에서 nuguApiProvider를 생성하고 주입하는 형태면 가장 이상적인 형태이겠지만, 사이드이펙트 우려가 있어서 streamDataRouter일 때에만 변경하도록 수정