### PR TITLE
TycheEndPointDetectorEngine 레이스 컨디션 요소 수정

### DIFF
--- a/JadeMarble/Sources/TycheEndPointDetectorEngine.swift
+++ b/JadeMarble/Sources/TycheEndPointDetectorEngine.swift
@@ -53,7 +53,7 @@ public class TycheEndPointDetectorEngine {
     public init() {}
     
     deinit {
-        internalStop()
+        releaseEPDIfNeeeded()
     }
     
     public func start(
@@ -204,12 +204,15 @@ public class TycheEndPointDetectorEngine {
         }
     }
     
+    private func releaseEPDIfNeeeded() {
+        guard engineHandle != nil else { return }
+        epdClientChannelRELEASE(engineHandle)
+        engineHandle = nil
+        log.debug("engine is destroyed")
+    }
+    
     private func internalStop() {
-        if engineHandle != nil {
-            epdClientChannelRELEASE(engineHandle)
-            engineHandle = nil
-            log.debug("engine is destroyed")
-        }
+        releaseEPDIfNeeeded()
         
         speexEncoder = nil
         state = .idle


### PR DESCRIPTION
## Summary
- TycheEndPointDetectorEngine 레이스 컨디션 요소 수정
  - deinit 이 TycheEndPointDetectorEngine 이 정의한 Queue에서 동작을 보장하지 않아서 생긴 현상
  - deinit에서 delegate를 사용해서 이벤트를 전달하고 있어 레이스 컨디션 발생
  - deinit에선 release만 수행하도록 적용 -> stop은 어자피 release되고 다시 Init되는 과정에서 값이 초기화됨 