### PR TITLE
[ADOTTPMTES-24297] ClientEndPointDetector 에서 EPDEngine 을 교체할 수 있는 Interface생성

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -706,7 +706,13 @@ private extension ASRAgent {
         
         switch asrRequest.options.endPointing {
         case .client:
-            endPointDetector = ClientEndPointDetector(asrOptions: asrRequest.options)
+            // TODO: EPD Engine Injection
+            let engine = TycheEndPointDetectorEngineAdapter()
+            
+            endPointDetector = ClientEndPointDetector(
+                asrOptions: asrRequest.options,
+                engine: engine
+            )
         case .server:
             // TODO: after server preparation.
             log.error("Server side end point detector does not support yet.")

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/ClientEndPointDetector.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/ClientEndPointDetector.swift
@@ -26,7 +26,7 @@ import JadeMarble
 
 class ClientEndPointDetector: EndPointDetectable {
     public weak var delegate: EndPointDetectorDelegate?
-    private let engine: TycheEndPointDetectorEngine
+    private let engine: EndPointDetectorEngineProtocol
     private let asrOptions: ASROptions
     
     private var state: EndPointDetectorState = .idle {
@@ -35,9 +35,12 @@ class ClientEndPointDetector: EndPointDetectable {
         }
     }
     
-    public init(asrOptions: ASROptions) {
+    public init(
+        asrOptions: ASROptions,
+        engine: EndPointDetectorEngineProtocol
+    ) {
         self.asrOptions = asrOptions
-        engine = TycheEndPointDetectorEngine()
+        self.engine = engine
         engine.delegate = self
     }
     
@@ -72,8 +75,8 @@ class ClientEndPointDetector: EndPointDetectable {
     }
 }
 
-extension ClientEndPointDetector: TycheEndPointDetectorEngineDelegate {
-    public func tycheEndPointDetectorEngineDidChange(state: TycheEndPointDetectorEngine.State) {
+extension ClientEndPointDetector: EndPointDetectorEngineDelegate {
+    public func endPointDetectorEngineDidChange(state: EndPointDetectorEngineState) {
         switch state {
         case .idle:
             self.state = .idle
@@ -96,7 +99,7 @@ extension ClientEndPointDetector: TycheEndPointDetectorEngineDelegate {
         }
     }
     
-    public func tycheEndPointDetectorEngineDidExtract(speechData: Data) {
+    public func endPointDetectorEngineDidExtract(speechData: Data) {
         delegate?.endPointDetectorSpeechDataExtracted(speechData: speechData)
     }
 }

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/Adapter/TycheEndPointDetectorEngineAdapter.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/Adapter/TycheEndPointDetectorEngineAdapter.swift
@@ -1,0 +1,96 @@
+//
+//  TycheEndPointDetectorEngineAdapter.swift
+//  nugu-ios
+//
+//  Created by 김승찬님/iOS개발팀 on 4/21/25.
+//  Copyright © 2025 SK Telecom Co., Ltd. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import AVFoundation
+
+import JadeMarble
+
+public class TycheEndPointDetectorEngineAdapter: EndPointDetectorEngineProtocol {
+    private let engine: TycheEndPointDetectorEngine
+    
+    public weak var delegate: EndPointDetectorEngineDelegate?
+    public var flushTime: Int
+    
+    public var state: EndPointDetectorEngineState {
+        return engineState(from: engine.state)
+    }
+    
+    init() {
+        self.engine = TycheEndPointDetectorEngine()
+        self.flushTime = engine.flushTime
+        engine.delegate = self
+    }
+    
+    public func start(
+        sampleRate: Double,
+        timeout: Int,
+        maxDuration: Int,
+        pauseLength: Int
+    ) {
+        engine.start(
+            sampleRate: sampleRate,
+            timeout: timeout,
+            maxDuration: maxDuration,
+            pauseLength: pauseLength
+        )
+    }
+    
+    public func putAudioBuffer(buffer: AVAudioPCMBuffer) {
+        engine.putAudioBuffer(buffer: buffer)
+    }
+    
+    public func stop() {
+        engine.stop()
+    }
+    
+    private func engineState(from tycheState: TycheEndPointDetectorEngine.State) -> EndPointDetectorEngineState {
+        switch tycheState {
+        case .idle:
+            return .idle
+        case .listening:
+            return .listening
+        case .start:
+            return .start
+        case .end:
+            return .end
+        case .timeout:
+            return .timeout
+        case .reachToMaxLength:
+            return .reachToMaxLength
+        case .finish:
+            return .finish
+        case .unknown:
+            return .unknown
+        case .error:
+            return .error
+        }
+    }
+}
+
+extension TycheEndPointDetectorEngineAdapter: TycheEndPointDetectorEngineDelegate {
+    public func tycheEndPointDetectorEngineDidChange(state: TycheEndPointDetectorEngine.State) {
+        delegate?.endPointDetectorEngineDidChange(state: engineState(from: state))
+    }
+    
+    public func tycheEndPointDetectorEngineDidExtract(speechData: Data) {
+        delegate?.endPointDetectorEngineDidExtract(speechData: speechData)
+    }
+}

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineDelegate.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineDelegate.swift
@@ -1,0 +1,27 @@
+//
+//  EndPointDetectorEngineProtocol.swift
+//  nugu-ios
+//
+//  Created by 김승찬님/iOS개발팀 on 4/21/25.
+//  Copyright © 2025 SK Telecom Co., Ltd. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import AVFoundation
+
+public protocol EndPointDetectorEngineDelegate: AnyObject {
+    func endPointDetectorEngineDidChange(state: EndPointDetectorEngineState)
+    func endPointDetectorEngineDidExtract(speechData: Data)
+}

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineDelegate.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  EndPointDetectorEngineProtocol.swift
+//  EndPointDetectorEngineDelegate.swift
 //  nugu-ios
 //
 //  Created by 김승찬님/iOS개발팀 on 4/21/25.

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineProtocol.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineProtocol.swift
@@ -1,0 +1,31 @@
+//
+//  EndPointDetectorEngineProtocol.swift
+//  nugu-ios
+//
+//  Created by 김승찬님/iOS개발팀 on 4/21/25.
+//  Copyright © 2025 SK Telecom Co., Ltd. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import AVFoundation
+
+public protocol EndPointDetectorEngineProtocol: AnyObject {
+    var delegate: EndPointDetectorEngineDelegate? { get set }
+    var flushTime: Int { get set }
+    
+    func start(sampleRate: Double, timeout: Int, maxDuration: Int, pauseLength: Int)
+    func putAudioBuffer(buffer: AVAudioPCMBuffer)
+    func stop()
+}

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineState.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineState.swift
@@ -1,0 +1,34 @@
+//
+//  EndPointDetectorEngineProtocol.swift
+//  nugu-ios
+//
+//  Created by 김승찬님/iOS개발팀 on 4/21/25.
+//  Copyright © 2025 SK Telecom Co., Ltd. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import AVFoundation
+
+public enum EndPointDetectorEngineState {
+    case idle
+    case listening
+    case start
+    case end
+    case timeout
+    case reachToMaxLength
+    case finish
+    case unknown
+    case error
+}

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineState.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/EndPointDetector/EndPointDetectorEngine/EndPointDetectorEngineState.swift
@@ -1,5 +1,5 @@
 //
-//  EndPointDetectorEngineProtocol.swift
+//  EndPointDetectorEngineState.swift
 //  nugu-ios
 //
 //  Created by 김승찬님/iOS개발팀 on 4/21/25.

--- a/nugu-ios.xcodeproj/project.pbxproj
+++ b/nugu-ios.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1190,6 +1190,10 @@
 		F7E224EC263957DE00E13F19 /* SpeechRecognizerAggregatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizerAggregatorError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		89BC6D162DB6130E00320FBD /* EndPointDetectorEngine */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = EndPointDetectorEngine; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		1FFFEFFA23753F1800C9A177 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -2229,6 +2233,7 @@
 		7303C68223C5BF5E00610343 /* EndPointDetector */ = {
 			isa = PBXGroup;
 			children = (
+				89BC6D162DB6130E00320FBD /* EndPointDetectorEngine */,
 				7303C68523C5BFD400610343 /* ClientEndPointDetector.swift */,
 				7303C68323C5BFD400610343 /* EndPointDetectorDelegate.swift */,
 				7303C68423C5BFD400610343 /* EndPointDetectorState.swift */,
@@ -3085,6 +3090,9 @@
 			dependencies = (
 				73152FD823E042D000F843C3 /* PBXTargetDependency */,
 				73152FEC23E05D1100F843C3 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				89BC6D162DB6130E00320FBD /* EndPointDetectorEngine */,
 			);
 			name = NuguAgents;
 			packageProductDependencies = (


### PR DESCRIPTION
## Description
- `ClientEndPointDetector` 와 `TycheEndPointDetectorEngine` 분리 

## Focus
- EndPointDetectorEngineProtocol 로 추상화 시켜, EPD 생성 시 주입받을 수 있도록 변경
  - 주입 위치는 추후 개선 예정
- 추가된 protocol
  - EndPointDetectorEngineProtocol
  - EndPointDetectorEngineDelegate
  - EndPointDetectorEngineState
- `TycheEndPointDetectorEngine` 의 경우, NuguAgents 내에서는 `TycheEndPointDetectorEngineAdapter` 를 활용하여 연결