### PR TITLE
TTS 재생이 완료 되면 currentPlayer를 nil로 변경

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/TextToSpeech/TTSAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/TextToSpeech/TTSAgent.swift
@@ -106,6 +106,8 @@ public final class TTSAgent: TTSAgentProtocol {
                     } else {
                         playSyncManager.endPlay(property: playSyncProperty)
                     }
+                    
+                    currentPlayer = nil
                 }
             default:
                 break


### PR DESCRIPTION
### 원인
- AudioPlayer가 재생 중 TTS.STOP으로 잘 못 내려오는 경우 player가 stop 되는 현상 발생
- TTS 재생은 완료 됐지만 tts의 player는 남아있는 상태로 이때 동일한 dialogRequestId로 PlayStack에서 제거하는 과정에서 audioPlayer가 stop 됨

### 해결
- TTS 재생이 완료 되면 currentPlayer를 제거함