### PR TITLE
decodeIfPresent에서 value가 null 인 경우 error exception 발생

### DIFF
--- a/NuguUtils/Sources/Extensions/KeyedDecodingContainerExtension.swift
+++ b/NuguUtils/Sources/Extensions/KeyedDecodingContainerExtension.swift
@@ -42,28 +42,32 @@ public extension KeyedDecodingContainer {
     }
     
     func decodeIfPresent(_ type: [String: AnyHashable].Type, forKey key: K) throws -> [String: AnyHashable]? {
-        guard contains(key) else {
+        guard contains(key),
+                try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)
     }
     
     func decodeIfPresent(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any]? {
-        guard contains(key) else {
+        guard contains(key),
+                try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)
     }
     
     func decodeIfPresent(_ type: [[String: AnyHashable]].Type, forKey key: K) throws -> [[String: AnyHashable]]? {
-        guard contains(key) else {
+        guard contains(key),
+                try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)
     }
     
     func decodeIfPresent(_ type: [[String: Any]].Type, forKey key: K) throws -> [[String: Any]]? {
-        guard contains(key) else {
+        guard contains(key),
+                try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)
@@ -80,14 +84,16 @@ public extension KeyedDecodingContainer {
     }
     
     func decodeIfPresent(_ type: [AnyHashable].Type, forKey key: K) throws -> [AnyHashable]? {
-        guard contains(key) else {
+        guard contains(key),
+                try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)
     }
     
     func decodeIfPresent(_ type: [Any].Type, forKey key: K) throws -> [Any]? {
-        guard contains(key) else {
+        guard contains(key),
+                try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)


### PR DESCRIPTION
### Description
#### 기대효과
- optional로 선언했으니 null인 경우 nil로 설정
#### 결과
- error exception 발생
#### 원인
- dictionay의 decodeIfPresent는 NuguUtil의 extension을 사용하고 있음
- 값 자체가 null인 경우에 decode를 하면서 exception throw
#### 수정
- null 인 경우 nil로 return 하도록 extension 수정