### PR TITLE
AudioPlayer.Template Directive 추가 및 AudioPlayerDirectivePreProcessor 추가

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
@@ -173,7 +173,9 @@ public final class AudioPlayerAgent: AudioPlayerAgentProtocol {
         DirectiveHandleInfo(namespace: capabilityAgentProperty.name, name: "ShowLyrics", blockingPolicy: BlockingPolicy(blockedBy: .any, blocking: nil), directiveHandler: handleShowLyrics),
         DirectiveHandleInfo(namespace: capabilityAgentProperty.name, name: "HideLyrics", blockingPolicy: BlockingPolicy(blockedBy: .any, blocking: nil), directiveHandler: handleHideLyrics),
         DirectiveHandleInfo(namespace: capabilityAgentProperty.name, name: "ControlLyricsPage", blockingPolicy: BlockingPolicy(blockedBy: .any, blocking: nil), directiveHandler: handleControlLyricsPage),
-        DirectiveHandleInfo(namespace: capabilityAgentProperty.name, name: "ShowPlaylist", blockingPolicy: BlockingPolicy(blockedBy: .any, blocking: nil), directiveHandler: handleShowPlaylist)
+        DirectiveHandleInfo(namespace: capabilityAgentProperty.name, name: "ShowPlaylist", blockingPolicy: BlockingPolicy(blockedBy: .any, blocking: nil), directiveHandler: handleShowPlaylist),
+        // Custom Directive
+        DirectiveHandleInfo(namespace: capabilityAgentProperty.name, name: "Template", blockingPolicy: BlockingPolicy(blockedBy: .any, blocking: nil), directiveHandler: handleTemplate)
     ]
     
     public init(
@@ -539,11 +541,6 @@ private extension AudioPlayerAgent {
                 }
                 self.currentPlayer = player
                 
-                self.audioPlayerDisplayManager.display(
-                    payload: player.payload,
-                    header: directive.header
-                )
-                
                 self.focusManager.requestFocus(channelDelegate: self)
                 
                 completion(.finished) // TODO: DirectiveHandleResult.started 추가
@@ -748,6 +745,28 @@ private extension AudioPlayerAgent {
                     ).rx
                 )
             }
+        }
+    }
+    
+    /// handle template directive for displaying audio player
+    func handleTemplate() -> HandleDirective {
+        return { [weak self] directive, completion in
+            guard let self else {
+                completion(.canceled)
+                return
+            }
+            
+            guard let payload = try? JSONDecoder().decode(AudioPlayerPlayPayload.self, from: directive.payload) else {
+                completion(.failed("Invalid payload"))
+                return
+            }
+            
+            audioPlayerDisplayManager.display(
+                payload: payload,
+                header: directive.header
+            )
+            
+            completion(.finished)
         }
     }
     

--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerDirectivePreProcessor.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerDirectivePreProcessor.swift
@@ -1,0 +1,41 @@
+//
+//  AudioPlayerDirectivePreProcessor.swift
+//  NuguAgents
+//
+//  Created by jaycesub on 2025/06/27.
+//  Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+import NuguCore
+
+public final class AudioPlayerDirectivePreProcessor: DirectivePreProcessable {
+    public func preProcess(directives: [Downstream.Directive]) -> [Downstream.Directive] {
+        guard (directives.contains { $0.header.namespace == CapabilityAgentCategory.display.name }) == false else { return directives }
+        
+        guard let playDirective = (directives.first { $0.header.type == "AudioPlayer.Play" }) else { return directives }
+        let templateHeaer: Downstream.Header = .init(
+            namespace: playDirective.header.namespace,
+            name: "Template",
+            dialogRequestId: playDirective.header.dialogRequestId,
+            messageId: playDirective.header.messageId,
+            version: playDirective.header.version
+        )
+        let templateDirective = Downstream.Directive.init(header: templateHeaer, payload: playDirective.payload)
+        
+        return [templateDirective] + directives
+    }
+}

--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerDirectivePreProcessor.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerDirectivePreProcessor.swift
@@ -23,6 +23,8 @@ import Foundation
 import NuguCore
 
 public final class AudioPlayerDirectivePreProcessor: DirectivePreProcessable {
+    public init() {}
+    
     public func preProcess(directives: [Downstream.Directive]) -> [Downstream.Directive] {
         guard (directives.contains { $0.header.namespace == CapabilityAgentCategory.display.name }) == false else { return directives }
         

--- a/NuguClientKit/Sources/Client/NuguClient+Builder.swift
+++ b/NuguClientKit/Sources/Client/NuguClient+Builder.swift
@@ -206,6 +206,8 @@ public extension NuguClient {
                 streamDataRouter: streamDataRouter,
                 directiveSequencer: directiveSequencer
             )
+            
+            directivesPreProcessor.add(AudioPlayerDirectivePreProcessor())
         }
 
         /**

--- a/nugu-ios.xcodeproj/project.pbxproj
+++ b/nugu-ios.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 		E649868428336C9E001AD733 /* DisplayHistoryControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E649868328336C9E001AD733 /* DisplayHistoryControl.swift */; };
 		E649868628336CED001AD733 /* DisplayRedirectTriggerChildPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E649868528336CED001AD733 /* DisplayRedirectTriggerChildPayload.swift */; };
 		E649868A28337649001AD733 /* ControlCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E649868928337649001AD733 /* ControlCenterManager.swift */; };
+		E6921CCD2E0E264500E084B3 /* AudioPlayerDirectivePreProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6921CCC2E0E264500E084B3 /* AudioPlayerDirectivePreProcessor.swift */; };
 		E69C17322BFAB8BF00AD26F0 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E69C17312BFAB8BF00AD26F0 /* RxSwift */; };
 		E69D1E002BFAB7D80061C704 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E69D1DFF2BFAB7D80061C704 /* RxSwift */; };
 		E6BE047C2A0BA1A400AE29E3 /* Image+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BE047B2A0BA1A400AE29E3 /* Image+Event.swift */; };
@@ -1167,6 +1168,7 @@
 		E649868328336C9E001AD733 /* DisplayHistoryControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayHistoryControl.swift; sourceTree = "<group>"; };
 		E649868528336CED001AD733 /* DisplayRedirectTriggerChildPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayRedirectTriggerChildPayload.swift; sourceTree = "<group>"; };
 		E649868928337649001AD733 /* ControlCenterManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlCenterManager.swift; sourceTree = "<group>"; };
+		E6921CCC2E0E264500E084B3 /* AudioPlayerDirectivePreProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerDirectivePreProcessor.swift; sourceTree = "<group>"; };
 		E6BE047B2A0BA1A400AE29E3 /* Image+Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Event.swift"; sourceTree = "<group>"; };
 		E6BE047D2A0BA1BD00AE29E3 /* ImageAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAgent.swift; sourceTree = "<group>"; };
 		E6BFB95B2C0698CB007AA282 /* Publishers+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publishers+Convenience.swift"; sourceTree = "<group>"; };
@@ -1795,6 +1797,7 @@
 				73E7E4C1294670E500361634 /* AudioPlayerResult.swift */,
 				06FE5684253EDB64002FAC9B /* AudioPlayer.swift */,
 				06FE568F253FCC1E002FAC9B /* AudioPlayerAgentError.swift */,
+				E6921CCC2E0E264500E084B3 /* AudioPlayerDirectivePreProcessor.swift */,
 			);
 			path = AudioPlayer;
 			sourceTree = "<group>";
@@ -3952,6 +3955,7 @@
 				737388D924A46C3C0018DDD2 /* SoundState.swift in Sources */,
 				737388E124A46C4A0018DDD2 /* ExtensionAgentDelegate.swift in Sources */,
 				73152FCB23E0415B00F843C3 /* DisplayAgent+Event.swift in Sources */,
+				E6921CCD2E0E264500E084B3 /* AudioPlayerDirectivePreProcessor.swift in Sources */,
 				7E284DA124DD482800BF9640 /* InteractionControlConst.swift in Sources */,
 				7E1DDE0D25F894A90038D040 /* Routine+Event.swift in Sources */,
 				73152FA923E0412D00F843C3 /* ExtensionAgent+Event.swift in Sources */,


### PR DESCRIPTION
### Description
- AudioPlayer.Template Directive 추가 및 AudioPlayerDirectivePreProcessor 추가

### Focus
- AudioPlayer.Play directive를 수신하고 directives에 Display.XXX가 존재하지 않으면 AudioPlayer.Template이라는 임의의 directive를 생성
- AudioPlayer.Template directive는 오디오플레이어 생성타이밍을 가장 앞으로 이동