### PR TITLE
AudioSessionManager 내 AudioPlayerAgent 의존성 제거

### DIFF
--- a/NuguClientKit/Sources/Audio/AudioSessionManageable.swift
+++ b/NuguClientKit/Sources/Audio/AudioSessionManageable.swift
@@ -29,9 +29,6 @@ public protocol AudioSessionManageable: AnyObject {
     @discardableResult func updateAudioSessionWhenCarplayConnected(requestingFocus: Bool) -> Bool
     @discardableResult func updateAudioSession(requestingFocus: Bool) -> Bool
     func notifyAudioSessionDeactivation()
-    
-    func enable()
-    func disable()
 }
 
 public extension AudioSessionManageable {

--- a/NuguClientKit/Sources/Client/NuguClient+Builder.swift
+++ b/NuguClientKit/Sources/Client/NuguClient+Builder.swift
@@ -170,7 +170,7 @@ public extension NuguClient {
          - note: If you want to control AVAudioSession yourself, Set this property to nil.
          Then NuguClientDelegate method will be called when the AVAudioSession is required.
          */
-        public lazy var audioSessionManager: AudioSessionManageable? = AudioSessionManager(audioPlayerAgent: audioPlayerAgent)
+        public lazy var audioSessionManager: AudioSessionManageable? = AudioSessionManager()
         
         /**
          Keyword Detector.


### PR DESCRIPTION
### Description
- AudioSessionManager 내 AudioPlayerAgent 의존성 제거

### Focus
- AudioSessionManager는 agent의 의존성이 엮여있으면 안되는 독립된 모듈이어야 하기 때문에 의존성 제거
- NuguClient에서 필요한 로직을 수행 후 메서드를 호출하게 변경