### PR TITLE
listening with trigger 버그 수정

### DIFF
--- a/NuguClientKit/Sources/Audio/KeywordDetector/KeywordDetector.swift
+++ b/NuguClientKit/Sources/Audio/KeywordDetector/KeywordDetector.swift
@@ -37,6 +37,7 @@ public class KeywordDetector: ContextInfoProvidable {
     /// Keyword detector state
     private(set) public var state: KeywordDetectorState = .inactive {
         didSet {
+            log.info("keyword state: \(state)")
             delegate?.keywordDetectorStateDidChange(state)
         }
     }

--- a/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
+++ b/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
@@ -279,7 +279,7 @@ extension SpeechRecognizerAggregator: MicInputProviderDelegate {
             keywordDetector.putAudioBuffer(buffer: buffer)
         }
         
-        if [.listening(), .recognizing].contains(asrAgent.asrState) {
+        if state != .wakeupTriggering, [.listening(), .recognizing].contains(asrAgent.asrState) {
             asrAgent.putAudioBuffer(buffer: buffer)
         }
     }


### PR DESCRIPTION
### Description
- listening with trigger 버그 수정

### Focus
- useKeywordDetector가 켜져있으면 마이크가 계속 열려있게 되고, 타이밍 이슈로 인해 음원이  EPD Engine 내 buffer에 들어가는 상황 발생
- state 로 마이크 차단