### PR TITLE
userRecognition priority 조정

### DIFF
--- a/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
+++ b/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
@@ -53,8 +53,6 @@ public class SpeechRecognizerAggregator: SpeechRecognizerAggregatable {
     public var useKeywordDetector = true
     private var isVoiceProcessingEnabled = false
     
-    private var lastRecognizeDialogRequestId: String?
-    
     // State
     private(set) public var state: SpeechRecognizerAggregatorState = .idle {
         didSet {
@@ -133,11 +131,7 @@ public extension SpeechRecognizerAggregator {
                 asrAgent.stopRecognition()
             }
             
-            if let lastRecognizeDialogRequestId {
-                directiveSequencer.cancelDirective(dialogRequestId: lastRecognizeDialogRequestId)
-            }
-            
-            lastRecognizeDialogRequestId = asrAgent.startRecognition(initiator: initiator, service: service, options: options) { [weak self] state in
+            asrAgent.startRecognition(initiator: initiator, service: service, options: options) { [weak self] state in
                 guard case .prepared = state else {
                     completion?(state)
                     return
@@ -224,9 +218,6 @@ public extension SpeechRecognizerAggregator {
                 keywordDetector.stop()
             }
             state = .cancelled
-            if let lastRecognizeDialogRequestId {
-                directiveSequencer.cancelDirective(dialogRequestId: lastRecognizeDialogRequestId)
-            }
             asrAgent.stopRecognition()
             stopMicInputProvider {
                 sema.signal()
@@ -320,7 +311,7 @@ extension SpeechRecognizerAggregator: KeywordDetectorDelegate {
                 end: end,
                 detection: detection
             )
-            lastRecognizeDialogRequestId = asrAgent.startRecognition(
+            asrAgent.startRecognition(
                 initiator: initiator,
                 service: service,
                 options: .init(endPointing: .client, requestType: requestType),

--- a/NuguCore/Sources/Focus/FocusChannelPriority.swift
+++ b/NuguCore/Sources/Focus/FocusChannelPriority.swift
@@ -40,7 +40,7 @@ public struct FocusChannelPriority {
     /// A priority of `call` channel.
     public static let call = FocusChannelPriority(requestPriority: 300, maintainPriority: 300)
     /// A priority of `userRecognition` channel.
-    public static let userRecognition = FocusChannelPriority(requestPriority: 300, maintainPriority: 250)
+    public static let userRecognition = FocusChannelPriority(requestPriority: 300, maintainPriority: 251)
     /// A priority of `dmRecognition` channel.
     public static let dmRecognition = FocusChannelPriority(requestPriority: 150, maintainPriority: 200)
     /// A priority of `alerts` channel.


### PR DESCRIPTION
### Description
- userRecognition priority 조정

### Focus
- 현재 ASRAgent 에서 focus를 가지고 있을 때 TTSAgent가 focus를 요청하면 가져갈 수 있음(userRecogition의 maintain priority가 information의 request priority가 같음)