### PR TITLE
AudioPlayerAgent 내 AudioSession 업데이트 하기전에 mode를 변경

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
@@ -351,8 +351,12 @@ public extension AudioPlayerAgent {
     }
     
     func updateAudioSessionIfNeeded() {
-        guard AVAudioSession.sharedInstance().mode == .voiceChat else { return }
         do {
+            try AVAudioSession.sharedInstance().setCategory(
+                .playAndRecord,
+                mode: .default,
+                options: [.defaultToSpeaker, .allowBluetoothA2DP]
+            )
             try AVAudioSession.sharedInstance().setActive(false)
             try AVAudioSession.sharedInstance().setCategory(
                 .playAndRecord,


### PR DESCRIPTION
### Description
- AudioPlayerAgent 내 AudioSession 업데이트 하기전에 mode를 변경

### Focus
- voiceChat -> default 로 변경할 때에는 mode를 먼저 바꿔야함